### PR TITLE
Dynamic port

### DIFF
--- a/tasks/http-server.js
+++ b/tasks/http-server.js
@@ -41,6 +41,7 @@ module.exports = function(grunt) {
 		};
 
 		var options = _.extend({}, defaults, this.data);
+		options.port = typeof options.port === 'function'  ? options.port(): options.port;
 
 		var server = Server.createServer(options);
 


### PR DESCRIPTION
Maybe if you use multiple projects you want to use dynamic ports, maybe this works:

module.exports = function( grunt ) {

  var server_port_number = 9000;
  grunt.initConfig({
    'http-server': {
      'dev': {
        port: function(){ return server_port_number; },
        ...
      }
    }

  grunt.registerTask('server', function( port ) {
    server_port_number = port == null ? 9000 : port;
    grunt.task.run('http-server:dev');
  });

To assign a port, we just exec:
grunt server:9090
