### PR TITLE
Add browser open flag to task

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ grunt.initConfig({
             https: {
                 cert: "cert.pem",
                 key : "key.pem"
-            }
+            },
+
+            openBrowser : false //open the browser to the URL/port when server starts.
 
         }
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -11,8 +11,10 @@ module.exports = function(grunt) {
             root            : "",
             host            : "127.0.0.1",
             port            : function(){ return 8585; },
-            https           : false
+            https           : false,
             //proxy           : "http://someurl.com"
+            
+            openBrowser     : true
         }
 
     }

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "http-server": "=0.8.0",
-    "lodash": "=3.10.X"
+    "http-server": "^0.8.0",
+    "lodash": "^3.10",
+    "opener": "~1.4.0"
   },
   "devDependencies": {
     "grunt": "*",

--- a/tasks/http-server.js
+++ b/tasks/http-server.js
@@ -16,6 +16,7 @@ Task:
         runInBackground: true|false,
         cors: true,
         logFn: requestLogger,
+        openBrowser : false
 
         https: {
             cert: "<file>",
@@ -29,7 +30,9 @@ Task:
 module.exports = function(grunt) {
 
     var Server = require('http-server'),
-        _ = require('lodash');
+        _ = require('lodash'),
+        opener = require("opener");
+
 
     var requestLogger = function(req, res, error) {
         var date = (new Date).toUTCString();
@@ -45,7 +48,8 @@ module.exports = function(grunt) {
         function () {
 
         // grunt async task
-        var done = this.async();
+        var done = this.async(),
+            protocol = "http:";
 
         var defaults = {
             root: process.cwd(),
@@ -58,7 +62,8 @@ module.exports = function(grunt) {
             runInBackground: false,
             cors: false,
             logFn: requestLogger,
-            https: false
+            https: false,
+            openBrowser : false
         };
 
         var options = _.extend({}, defaults, this.data);
@@ -70,7 +75,10 @@ module.exports = function(grunt) {
                 cert: __dirname + "/../files/cert.pem",
                 key:  __dirname + "/../files/key.pem"
             };
+
+            protocol : "https:";
         }
+
 
         var server = Server.createServer(options);
 
@@ -82,6 +90,14 @@ module.exports = function(grunt) {
             console.log(
                 _.template("Server running on <%= protocol %>://<%= host %>:<%= port %>/")(msgData));
             console.log('Hit CTRL-C to stop the server');
+
+            if (options.openBrowser)
+            {
+                console.log("Opening browser")
+                opener(protocol + '//' + options.host + ':' + options.port,
+                    { command: options.openBrowser !== true ? options.openBrowser : null }
+                );
+            }
         });
 
         process.on('SIGINT', function () {
@@ -95,5 +111,7 @@ module.exports = function(grunt) {
         if(options.runInBackground)
             done();
         });
+
+    
 }
 


### PR DESCRIPTION
With the regular http-server module, you can pass in the `-o` flag on the command line to signify open a new browser window or tab on creation of the server.  Unfortunately, there is no direct way to call that flag via a task runner because the http-server module executes that action only when that flag exists on the command line.

This patch sets a `openBrowser` value set to false by default, revises the construction of the URL for the browser to differentiate between http/https and calls `opener` with the `openBrowser` value.  I agree that this is a case of repeating existing code, but the open browser functionality is not exposed outside of the http-server module.  Until the http-server project is revised to accept the open browser flag as an external option, rather than a command line flag, there is little to be done.