### PR TITLE
Use newer version of http-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "divhide": "2.0.1",
-    "http-server": "0.9.0",
+    "http-server": "^0.11.1",
     "lodash": "4.2.X",
     "opener": "1.4.1",
     "showdown": "^1.3.0"


### PR DESCRIPTION
http-server v0.9.0 triggers a security warning due to dependence on an older version of ecstatic, new http-server uses a newer version which is safer.